### PR TITLE
Patternfly fail to provide bootstrap & jQuery

### DIFF
--- a/projects/accidentalert-ui/gulpfile.js
+++ b/projects/accidentalert-ui/gulpfile.js
@@ -113,13 +113,16 @@ gulp.task("copy:libs", ['clean'], function () {
     var assets = {
         css: [
             paths.node_modules + "patternfly/dist/css/**",
-            paths.node_modules + "patternfly/node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css"
+//            paths.node_modules + "patternfly/node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css"
+            paths.node_modules + "bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css"
         ],
         js: [
             paths.node_modules + "patternfly/dist/js/**",
             paths.node_modules + "patternfly/node_modules/jquery/dist/**",
-            paths.node_modules + "patternfly/node_modules/bootstrap/dist/js/**",
-            paths.node_modules + "patternfly/node_modules/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js"
+//            paths.node_modules + "patternfly/node_modules/bootstrap/dist/js/**",
+            paths.node_modules + "bootstrap/dist/js/**",
+//            paths.node_modules + "patternfly/node_modules/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js"
+            paths.node_modules + "bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js"
         ],
         fonts: [
             paths.node_modules + "patternfly/dist/fonts/**"

--- a/projects/accidentalert-ui/package.json
+++ b/projects/accidentalert-ui/package.json
@@ -30,6 +30,8 @@
     "lodash": "^4.17.4",
     "yn": "^2.0.0",
     "patternfly": "^3.37.1"
+    "jquery": "^3.3.1"
+    "bootstrap-datepicker": "^1.8.0"
   },
   "dependencies": {
     "http-server": "^0.11.1"

--- a/projects/accidentalert-ui/package.json
+++ b/projects/accidentalert-ui/package.json
@@ -29,8 +29,8 @@
     "gulp-webserver": "^0.9.1",
     "lodash": "^4.17.4",
     "yn": "^2.0.0",
-    "patternfly": "^3.37.1"
-    "jquery": "^3.3.1"
+    "patternfly": "^3.37.1",
+    "jquery": "^3.3.1",
     "bootstrap-datepicker": "^1.8.0"
   },
   "dependencies": {


### PR DESCRIPTION
Originally, Patternfly should provide node_modules of bootstrap/bootstrap-datepicker & jQuery. But it doesn't for the version listed in package.json.

temporarily add bootstrap & jquery package outside of the patternfly